### PR TITLE
fix: 解决分词时候遇到驼峰式文本的时候两个字母的分词不准确的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ class Helper {
   ) { }
 
   public spliteWord(text: string): string {
-    const camelReg = /([a-z])([A-Z][a-z])/g
+    const camelReg = /([a-z])([A-Z])(?=[a-z])/g
     const underlineReg = /([a-zA-Z])_([a-zA-Z])/g
     return text.replace(camelReg, '$1 $2').replace(underlineReg, '$1 $2').toLowerCase()
   }


### PR DESCRIPTION
比如说:
getIsContainRelatedOp的分词后会变成get iscontain related op,  这里的is和contain并没有被切分开,
所以这里采用环视的方案进行匹配, 解决以上问题